### PR TITLE
Fixed comment identification.

### DIFF
--- a/the-obfuscatorinator/src/main/java/com/theobfuscatorinator/codeInterpreter/CodeStructure.java
+++ b/the-obfuscatorinator/src/main/java/com/theobfuscatorinator/codeInterpreter/CodeStructure.java
@@ -40,17 +40,27 @@ public class CodeStructure {
             codeFile = input;
             fileName = codeFile.getName();
             originalCode = new String(Files.readAllBytes(input.toPath()));
-            unCommentedCode = removeComments(originalCode);
 
-            classes = identifyClasses(unCommentedCode);
+            classes = identifyClasses(originalCode);
 
             this.decryptionMethodName = Renamer.generateClassName();
             
             unCommentedCode = StringEncryption.encryptStrings(this, this.decryptionMethodName);
+
+            unCommentedCode = removeComments(unCommentedCode);
         }
         else {
             throw new IllegalArgumentException("Cannot make a code structure out of a directory.");
         } 
+    }
+
+    /**
+     * Get the original code.
+     * 
+     * @return The original code.
+     */
+    public String getOriginalCode() {
+        return originalCode;
     }
 
     /**
@@ -95,21 +105,21 @@ public class CodeStructure {
                 boolean foundEnd = false;
 
                 // Loop until we find the end of the string literal.
-                while (!foundEnd) {
+                while (!foundEnd && i >= 0) {
                     // If we find a double quote, then we have found the end of the string literal.
                     // Only if we find a double quote that is not escaped by a backslash.
                     if (copy.charAt(i) == '"') {
-                        if (i > 0 && copy.charAt(i-1) != '\\') {
-                            foundEnd = true;
-                        }
-                        else {
+                        if (i - 1 >= 0 && copy.charAt(i - 1) == '\\') {
                             i--;
                         }
-                    } else {
+                        else {
+                            foundEnd = true;
+                        }
+                    }
+                    else {
                         i--;
                     }
                 }
-                
                 // Remove the string literal from the code.
                 output = output.substring(0, i) + output.substring(j + 1);
 
@@ -180,6 +190,7 @@ public class CodeStructure {
     private ArrayList<ClassStructure> identifyClasses(String code) {
         ArrayList<ClassStructure> classes = new ArrayList<>();
         String removedStringsCode = removeStrings(code);
+        removedStringsCode = removeComments(removedStringsCode);
         Pattern classFinder = Pattern.compile("\\s+class\\s+");
         Matcher classMatcher = classFinder.matcher(removedStringsCode);
         int index = 0;

--- a/the-obfuscatorinator/src/main/java/com/theobfuscatorinator/codeInterpreter/Renamer.java
+++ b/the-obfuscatorinator/src/main/java/com/theobfuscatorinator/codeInterpreter/Renamer.java
@@ -172,7 +172,7 @@ public class Renamer {
                 if (index - 1 >= 0) {
                     char charBefore = codeToUpdate.charAt(index - 1);
                     String before = String.valueOf(charBefore);
-                    Pattern methodFinder = Pattern.compile("[^a-zA-Z!@#$%\\^&*0-9]{1}");
+                    Pattern methodFinder = Pattern.compile("[^a-zA-Z@#$0-9]{1}");
                     Matcher matcher = methodFinder.matcher(before);
                     if (matcher.matches()) {
                         validBefore = true;

--- a/the-obfuscatorinator/src/main/java/com/theobfuscatorinator/stringencryption/StringEncryption.java
+++ b/the-obfuscatorinator/src/main/java/com/theobfuscatorinator/stringencryption/StringEncryption.java
@@ -33,7 +33,7 @@ public class StringEncryption {
      */
     private static ArrayList<Pair<String, Integer>> findStrings(CodeStructure codeStructure) {
         ArrayList<Pair<String, Integer>> strings = new ArrayList<Pair<String, Integer>>();
-        String code = codeStructure.getUnCommentedCode().substring(0);
+        String code = codeStructure.getOriginalCode().substring(0);
 
         // Find all strings in the code
         int i = 0;
@@ -42,13 +42,20 @@ public class StringEncryption {
                 int j = i + 1;
                 while (j < code.length()) {
                     // Make sure it is not an escaped quote.
-                    if (code.charAt(j) == '"' && code.charAt(j - 1) != '\\') {
+                    if (code.charAt(j) == '"') {
+                        if (j - 1 > i && code.charAt(j - 1) == '\\') {
+                            if (j - 2 > i && code.charAt(j - 2) == '\\') {
+                                break;
+                            }
+                            j++;
+                            continue;
+                        }
                         break;
                     }
                     j++;
                 }
                 strings.add(new Pair<String, Integer>(code.substring(i, j+1), i));
-                i = j + 1;
+                i = j;
             }
             i++;
         }
@@ -79,7 +86,7 @@ public class StringEncryption {
     public static String encryptStrings(CodeStructure codeStructure, String decryptionMethodName) {
         
         ArrayList<Pair<String, Integer>> strings = findStrings(codeStructure);
-        String code = codeStructure.getUnCommentedCode().substring(0);
+        String code = codeStructure.getOriginalCode().substring(0);
 
         Random random = new Random();
         


### PR DESCRIPTION
When removing comments before removing Strings, parts of strings could
be identified as a comment. For example: "//test" would first be
identified as a comment so anything after '//' would be removed. To fix
this Strings are now encrypted first, essentially removed, before
removing comments.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] JUnit Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior caused by the change?**


* **Does this PR require all other workers to pull?** 


* **Other information**:



Source for template: https://github.com/axolo-co

